### PR TITLE
fix(ci): update checkout and Rector configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     name: PHP ${{ matrix.php }} - ${{ matrix.prefer-lowest == 1 && 'Lowest' || 'Latest' }} Dependencies
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - uses: RevoTale/php-composer-testing-action@v1
       with:
         php-version: ${{ matrix.php }}
@@ -25,7 +25,7 @@ jobs:
   Rector:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - uses: RevoTale/php-composer-testing-action@v1
       with:
         php-version: 8.4
@@ -35,7 +35,7 @@ jobs:
   PHPStan:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - uses: RevoTale/php-composer-testing-action@v1
       with:
         php-version: 8.4

--- a/rector.php
+++ b/rector.php
@@ -11,6 +11,7 @@ return RectorConfig::configure()
     ])
     ->withPreparedSets(
         deadCode: true,
+        codeQuality: true,
         codingStyle: true,
         typeDeclarations: true,
         privatization: true,

--- a/rector.php
+++ b/rector.php
@@ -14,7 +14,6 @@ return RectorConfig::configure()
         codingStyle: true,
         typeDeclarations: true,
         privatization: true,
-        strictBooleans: true,
         rectorPreset: true
     )
 ;

--- a/src/DataAdapters/Entities/Document/TrackingItem.php
+++ b/src/DataAdapters/Entities/Document/TrackingItem.php
@@ -116,13 +116,13 @@ final readonly class TrackingItem extends DocumentInfo
     public function getTrackingUpdateTime(): ?Timestamp
     {
         $date = $this->getNullableField('TrackingUpdateDate')->string();
-        return $date !== null && $date !== '' && $date !== '0' ? Timestamp::fromFormat('Y-m-d H:i:s', $date, NovaPoshtaAPI::getTimeZone()) : null;
+        return !in_array($date, [null, '', '0'], true) ? Timestamp::fromFormat('Y-m-d H:i:s', $date, NovaPoshtaAPI::getTimeZone()) : null;
     }
 
     public function getActualDeliveryTime(): ?Timestamp
     {
         $date = $this->getNullableField('ActualDeliveryDate')->string();
-        return $date !== null && $date !== '' && $date !== '0' ? Timestamp::fromFormat('Y-m-d H:i:s', $date, NovaPoshtaAPI::getTimeZone()) : null;
+        return !in_array($date, [null, '', '0'], true) ? Timestamp::fromFormat('Y-m-d H:i:s', $date, NovaPoshtaAPI::getTimeZone()) : null;
     }
 
     public function getStatusDescription(): string

--- a/src/DataAdapters/Entities/Location/SettlementStreetItem.php
+++ b/src/DataAdapters/Entities/Location/SettlementStreetItem.php
@@ -42,7 +42,7 @@ final readonly class SettlementStreetItem extends Entity
         $index = 0;
         $location = $this->getField('Location')->list();
         if (!isset($location[$index])) {
-            throw new BadValueException('Location has incomplete coordinates', key: 'Location', value: null);
+            throw new BadValueException('Location has incomplete coordinates', value: null, key: 'Location');
         }
 
         return $location[$index]->integer();
@@ -56,7 +56,7 @@ final readonly class SettlementStreetItem extends Entity
         $index = 1;
         $location = $this->getField('Location')->list();
         if (!isset($location[$index])) {
-            throw new BadValueException('Location has incomplete coordinates', key: 'Location', value: null);
+            throw new BadValueException('Location has incomplete coordinates', value: null, key: 'Location');
         }
 
         return $location[$index]->integer();

--- a/src/DataAdapters/Result/AdditionalService/ShippingDataUpdateRequestResult.php
+++ b/src/DataAdapters/Result/AdditionalService/ShippingDataUpdateRequestResult.php
@@ -29,7 +29,7 @@ final readonly class ShippingDataUpdateRequestResult extends Result
     {
         $objects = $this->container->getDataAsObjectList();
         if ([] === $objects) {
-            throw new BadValueException(message:'No single object returned', key: 'Data', value: $objects);
+            throw new BadValueException(message:'No single object returned', value: $objects, key: 'Data');
         }
 
         return $objects[0];

--- a/src/Normalizer/ObjectNormalizer.php
+++ b/src/Normalizer/ObjectNormalizer.php
@@ -28,7 +28,7 @@ final readonly class ObjectNormalizer
     public function field(string $key): ValueNormalizer
     {
         if (!isset($this->data[$key])) {
-            throw $this->exceptionFactory->createBadValueException('Field key not exist', key: $key, value: null);
+            throw $this->exceptionFactory->createBadValueException('Field key not exist', value: null, key: $key);
         }
 
         return new ValueNormalizer($this->data[$key], $this->exceptionFactory);

--- a/src/NovaPoshtaAPI.php
+++ b/src/NovaPoshtaAPI.php
@@ -58,7 +58,7 @@ class NovaPoshtaAPI implements LoggerAwareInterface
                 'calledMethod' => $method,
                 'methodProperties' => $params === [] ? new stdClass() : $params,
             ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE);
-            $logger->info('Requested NovaPoshta service', compact('model', 'method', 'params'));
+            $logger->info('Requested NovaPoshta service', ['model' => $model, 'method' => $method, 'params' => $params]);
         } catch (JsonException $jsonException) {
             throw new JsonEncodeException($jsonException);
         }

--- a/src/Services/SettlementService.php
+++ b/src/Services/SettlementService.php
@@ -29,7 +29,7 @@ final readonly class SettlementService extends Service
             $data['RegionRef'] = $regionRef;
         }
 
-        if ($areaRef !== null && $areaRef !== '' && $areaRef !== '0') {
+        if (!in_array($areaRef, [null, '', '0'], true)) {
             $data['AreRef'] = $areaRef;
         }
 


### PR DESCRIPTION
## Summary

- update `actions/checkout` from v6 to v7
- remove Rector's obsolete `strictBooleans` prepared-set argument
- enable Rector's recommended `codeQuality` set alongside the existing `codingStyle` set
- apply the six resulting Rector transformations

## Cause

Renovate PR #28 is not failing because of checkout v7. This repository does not commit `composer.lock`, so CI resolved Rector 2.6.2. That version removed the deprecated `strictBooleans` named argument, causing Rector to stop before analysis with `Unknown named parameter $strictBooleans`.

In Rector 2.5, `strictBooleans` was already a no-op and recommended using `codeQuality` plus `codingStyle` instead. This PR enables that replacement and preserves the intended checkout update.

This PR replaces #28.

## Validation

Using the repository-defined PHP 8.5 devcontainer image:

- `composer validate --strict`
- `composer run-script rector:test`
- `composer run-script phpstan`
- `composer run-script phpunit`
